### PR TITLE
Add license metadata to PyPI package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     author_email='sray@cs.cmu.edu',
     description='Search for 2-d projection boxes separating out classes/quantiles of output',
     keywords='d3m_primitive',
+    license='MIT',
     ext_modules=[find_projections_module],
     packages=['find_projections'],
     entry_points={


### PR DESCRIPTION
The package shows as `UNKNOWN` right now and people have to come to the repository to find the LICENSE file.