### PR TITLE
Add build requirement on numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy==1.18.2"]


### PR DESCRIPTION
The allows PEP-518 compatible build systems to correctly build and install find_projections.