### PR TITLE
Use a more compatible name for boost lib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ find_projections_module = Extension('libfind_projections',
                                              'find_projections/pyfind_projections.cpp'],
                                     include_dirs=[np.get_include()],
                                     extra_compile_args=['-pthread', '-std=c++14'],
-                                    extra_link_args=['-shared', '-pthread', '-lboost_python-py36']
+                                    extra_link_args=['-shared', '-pthread', '-lboost_python3']
                                     )
 
 setup(


### PR DESCRIPTION
`-lboost_python3` still works on Ubuntu, but additionally works on RedHat/CentOS (whereas `-lboost_python-py36` doesn't).